### PR TITLE
Optimize call and add “Processor Variables and Constants” support

### DIFF
--- a/m/base.go
+++ b/m/base.go
@@ -142,10 +142,10 @@ func init() {
 		},
 	})
 
-	transpiler.RegisterFuncTranslation("GetHealth", CreateSensorFuncTranslation("@health"))
-	transpiler.RegisterFuncTranslation("GetName", CreateSensorFuncTranslation("@name"))
-	transpiler.RegisterFuncTranslation("GetX", CreateSensorFuncTranslation("@x"))
-	transpiler.RegisterFuncTranslation("GetY", CreateSensorFuncTranslation("@y"))
+	transpiler.RegisterFuncTranslation("GetHealth", createSensorFuncTranslation("@health"))
+	transpiler.RegisterFuncTranslation("GetName", createSensorFuncTranslation("@name"))
+	transpiler.RegisterFuncTranslation("GetX", createSensorFuncTranslation("@x"))
+	transpiler.RegisterFuncTranslation("GetY", createSensorFuncTranslation("@y"))
 }
 
 // Read a float64 value from memory at specified position
@@ -186,7 +186,7 @@ func Sensor(block HealthC, sense string) float64 {
 	return 0
 }
 
-func CreateSensorFuncTranslation(attribute string) transpiler.Translator {
+func createSensorFuncTranslation(attribute string) transpiler.Translator {
 	return transpiler.Translator{
 		Count: func(args []transpiler.Resolvable, vars []transpiler.Resolvable) int {
 			return 1

--- a/m/base.go
+++ b/m/base.go
@@ -141,6 +141,11 @@ func init() {
 			}, nil
 		},
 	})
+
+	transpiler.RegisterFuncTranslation("GetHealth", CreateSensorFuncTranslation("@health"))
+	transpiler.RegisterFuncTranslation("GetName",CreateSensorFuncTranslation("@name"))
+	transpiler.RegisterFuncTranslation("GetX",CreateSensorFuncTranslation("@x"))
+	transpiler.RegisterFuncTranslation("GetY",CreateSensorFuncTranslation("@y"))
 }
 
 // Read a float64 value from memory at specified position
@@ -172,11 +177,34 @@ func GetLink(address int) Link {
 // Retrieve a list of units that match specified conditions
 //
 // Conditions are combined using an `and` operation
-func Radar(from string, target1 RadarTarget, target2 RadarTarget, target3 RadarTarget, sortOrder bool, sort RadarSort) Unit {
+func Radar(from interface{}, target1 RadarTarget, target2 RadarTarget, target3 RadarTarget, sortOrder bool, sort RadarSort) Unit {
 	return nil
 }
 
 // Extract information indicated by sense from the provided block
 func Sensor(block interface{}, sense string) float64 {
 	return 0
+}
+
+func CreateSensorFuncTranslation(attribute string) transpiler.Translator{
+	return transpiler.Translator{
+		Count: func(args []transpiler.Resolvable, vars []transpiler.Resolvable) int {
+			return 1
+		},
+		Variables: 1,
+		Translate: func(args []transpiler.Resolvable, vars []transpiler.Resolvable) ([]transpiler.MLOGStatement, error) {
+			return []transpiler.MLOGStatement{
+				&transpiler.MLOG{
+					Statement: [][]transpiler.Resolvable{
+						{
+							&transpiler.Value{Value: "sensor"},
+							vars[0],
+							&transpiler.Value{Value: strings.Trim(args[0].GetValue(), "\"")},
+							&transpiler.Value{Value: attribute},
+						},
+					},
+				},
+			}, nil
+		},
+	}
 }

--- a/m/base.go
+++ b/m/base.go
@@ -143,9 +143,9 @@ func init() {
 	})
 
 	transpiler.RegisterFuncTranslation("GetHealth", CreateSensorFuncTranslation("@health"))
-	transpiler.RegisterFuncTranslation("GetName",CreateSensorFuncTranslation("@name"))
-	transpiler.RegisterFuncTranslation("GetX",CreateSensorFuncTranslation("@x"))
-	transpiler.RegisterFuncTranslation("GetY",CreateSensorFuncTranslation("@y"))
+	transpiler.RegisterFuncTranslation("GetName", CreateSensorFuncTranslation("@name"))
+	transpiler.RegisterFuncTranslation("GetX", CreateSensorFuncTranslation("@x"))
+	transpiler.RegisterFuncTranslation("GetY", CreateSensorFuncTranslation("@y"))
 }
 
 // Read a float64 value from memory at specified position
@@ -177,16 +177,16 @@ func GetLink(address int) Link {
 // Retrieve a list of units that match specified conditions
 //
 // Conditions are combined using an `and` operation
-func Radar(from interface{}, target1 RadarTarget, target2 RadarTarget, target3 RadarTarget, sortOrder bool, sort RadarSort) Unit {
+func Radar(from Building, target1 RadarTarget, target2 RadarTarget, target3 RadarTarget, sortOrder bool, sort RadarSort) Unit {
 	return nil
 }
 
 // Extract information indicated by sense from the provided block
-func Sensor(block interface{}, sense string) float64 {
+func Sensor(block HealthC, sense string) float64 {
 	return 0
 }
 
-func CreateSensorFuncTranslation(attribute string) transpiler.Translator{
+func CreateSensorFuncTranslation(attribute string) transpiler.Translator {
 	return transpiler.Translator{
 		Count: func(args []transpiler.Resolvable, vars []transpiler.Resolvable) int {
 			return 1

--- a/m/types.go
+++ b/m/types.go
@@ -58,11 +58,18 @@ const (
 
 type Link = interface{}
 
-type Unit = interface{}
+type HealthC = interface{
+	GetHealth() int
+	GetName() string
+	GetX() float64
+	GetY() float64
+}
 
-type HealthC = interface{}
+type Unit = interface{
+	HealthC
+}
 
-type Building = struct {
+type Building = interface {
 	HealthC
 }
 

--- a/m/types.go
+++ b/m/types.go
@@ -30,6 +30,18 @@ func init() {
 	transpiler.RegisterSelector("m.BReactor", BReactor)
 	transpiler.RegisterSelector("m.BUnitModifier", BUnitModifier)
 	transpiler.RegisterSelector("m.BExtinguisher", BExtinguisher)
+
+	transpiler.RegisterSelector("m.This", ThisVar)
+	transpiler.RegisterSelector("m.ThisX", ThisXVar)
+	transpiler.RegisterSelector("m.ThisY", ThisYVar)
+	transpiler.RegisterSelector("m.Ipt", IptVar)
+	transpiler.RegisterSelector("m.Counter", CounterVar)
+	transpiler.RegisterSelector("m.Links", LinksVar)
+	transpiler.RegisterSelector("m.CurUnit", CurUnitVar)
+	transpiler.RegisterSelector("m.Time", TimeVar)
+	transpiler.RegisterSelector("m.Tick", TickVar)
+	transpiler.RegisterSelector("m.MapW", MapWVar)
+	transpiler.RegisterSelector("m.MapH", MapHVar)
 }
 
 type RadarTarget = string
@@ -58,20 +70,43 @@ const (
 
 type Link = interface{}
 
-type HealthC = interface{
+type HealthC = interface {
 	GetHealth() int
 	GetName() string
 	GetX() float64
 	GetY() float64
 }
 
-type Unit = interface{
+type Unit = interface {
 	HealthC
 }
 
 type Building = interface {
 	HealthC
 }
+
+var (
+	This    Building
+	ThisX   float64
+	ThisY   float64
+	CurUnit Unit
+)
+
+type SpecialVar = string
+
+const (
+	ThisVar    = SpecialVar("@this")
+	ThisXVar   = SpecialVar("@thisx")
+	ThisYVar   = SpecialVar("@thisy")
+	IptVar     = SpecialVar("@ipt")
+	CounterVar = SpecialVar("@counter")
+	LinksVar   = SpecialVar("@links")
+	CurUnitVar = SpecialVar("@unit")
+	TimeVar    = SpecialVar("@time")
+	TickVar    = SpecialVar("@tick")
+	MapWVar    = SpecialVar("@mapw")
+	MapHVar    = SpecialVar("@maph")
+)
 
 type BlockFlag = string
 

--- a/m/unit.go
+++ b/m/unit.go
@@ -177,19 +177,19 @@ func UnitLocateOre(ore string) (x int, y int, found bool) {
 //
 // Also locates blocks outside the range of the unit
 func UnitLocateBuilding(buildingType BlockFlag, enemy bool) (x int, y int, found bool, building Building) {
-	return 0, 0, false, Building{}
+	return 0, 0, false, nil
 }
 
 // Locate the enemy spawn
 //
 // Also locates blocks outside the range of the unit
 func UnitLocateSpawn() (x int, y int, found bool, building Building) {
-	return 0, 0, false, Building{}
+	return 0, 0, false,nil
 }
 
 // Locate a damaged building
 //
 // Also locates blocks outside the range of the unit
 func UnitLocateDamaged() (x int, y int, found bool, building Building) {
-	return 0, 0, false, Building{}
+	return 0, 0, false, nil
 }

--- a/m/unit.go
+++ b/m/unit.go
@@ -184,7 +184,7 @@ func UnitLocateBuilding(buildingType BlockFlag, enemy bool) (x int, y int, found
 //
 // Also locates blocks outside the range of the unit
 func UnitLocateSpawn() (x int, y int, found bool, building Building) {
-	return 0, 0, false,nil
+	return 0, 0, false, nil
 }
 
 // Locate a damaged building

--- a/m/unit_control.go
+++ b/m/unit_control.go
@@ -396,7 +396,7 @@ func UnitBuild(x float64, y float64, block string, rotation int, config int) {
 
 // Retrieve the building and its type at the specified absolute position
 func UnitGetBlock(x float64, y float64) (blockType string, building Building) {
-	return "", Building{}
+	return "", nil
 }
 
 // Checks whether there is a unit within the specified radius around the provided absolute position

--- a/tests/base_test.go
+++ b/tests/base_test.go
@@ -43,6 +43,16 @@ func TestBase(t *testing.T) {
 			input:  TestMain(`x := m.Sensor("A", "B")`),
 			output: `sensor _main_x A B`,
 		},
+		{
+			name:   "Sensor_GetHealth",
+			input:  TestMain(`x := y.GetHealth()`),
+			output: `sensor _main_x _main_y @health`,
+		},
+		{
+			name:   "Radar_This",
+			input:  TestMain(`x := m.Radar(m.This, m.RTAlly, m.RTEnemy, m.RTBoss, 0, m.RSArmor)`),
+			output: `radar ally enemy boss armor @this 0 _main_x`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
1.Optimize sensor call.
Example:
m.sensor(a, "@health") =>>a.GetHealth()
2.add “Processor Variables and Constants” support
Now you can use：
leader := m.Radar(m.This, m.RTAny, m.RTAny,m.RTAny, false, m.RSDistance)
m.UnitApproach(m.ThisX,m.ThisY,10)